### PR TITLE
Remove "--gpus all" flag

### DIFF
--- a/workbench/src/task-environment/createTaskEnvironment.ts
+++ b/workbench/src/task-environment/createTaskEnvironment.ts
@@ -215,7 +215,7 @@ export async function createTaskEnvironment(
     .filter(({ hostname }) => hostname !== null)
     .map(({ hostname, ipAddress }) => `--add-host=${hostname}:${ipAddress}`)
     .join(' ')
-  execSync(`docker run -dit ${addHostArguments} --gpus all --name ${containerName} ${imageName} bash -c "sleep infinity"`, {
+  execSync(`docker run -dit ${addHostArguments} --name ${containerName} ${imageName} bash -c "sleep infinity"`, {
     stdio: 'inherit',
   })
 


### PR DESCRIPTION
This flag was previously added so I can provision host GPUs in the docker container, this isn't needed as of now and can in fact break builds. 